### PR TITLE
[BUGFIX] Fix dependency conflict with qc_be_pagelanguage

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -19,7 +19,7 @@ $EM_CONF[$_EXTKEY] = [
             'fluid' => '12.4.10-12.4.99',
         ],
         'conflicts' => [
-            'qc_be_pagelanguage' => '1.0.0-9.9.99'
+            'qc_be_pagelanguage' => '1.0.0-1.0.1'
         ],
         'suggests' => [],
     ],


### PR DESCRIPTION
The conflict with qc_be_pagelanguage no longer exists for later versions since 1.0.2. The conflict in composer.json was already correctly changed, but not the version conflict in ext_emconf.php.

This is now fixed.