### PR TITLE
[BUGFIX] Fix typo3 13.4 dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,9 +26,9 @@
 		}
 	},
 	"require": {
-		"typo3/cms-core": "^12.4 || 13.4",
-		"typo3/cms-backend": "^12.4 || 13.4",
-		"typo3/cms-fluid": "^12.4 || 13.4"
+		"typo3/cms-core": "^12.4 || ^13.4",
+		"typo3/cms-backend": "^12.4 || ^13.4",
+		"typo3/cms-fluid": "^12.4 || ^13.4"
 	},
 	"require-dev": {
 		"friendsofphp/php-cs-fixer": "^3.0",


### PR DESCRIPTION
Add "^" because package blocks core upgrades without it