### PR TITLE
[BUGFIX] Do not show close button in v13

### DIFF
--- a/Classes/EventListener/PageLayoutListener.php
+++ b/Classes/EventListener/PageLayoutListener.php
@@ -19,9 +19,11 @@ class PageLayoutListener
     protected IconFactory $iconFactory;
     protected array $extConf;
 
-    public function __construct(IconFactory $iconFactory, ExtensionConfiguration $extensionConfiguration,
-        protected Typo3Version $typo3Version)
-    {
+    public function __construct(
+        IconFactory $iconFactory,
+        ExtensionConfiguration $extensionConfiguration,
+        protected Typo3Version $typo3Version
+    ) {
         $this->iconFactory = $iconFactory;
         $this->extConf = $extensionConfiguration->get('page_callouts');
     }

--- a/Classes/EventListener/PageLayoutListener.php
+++ b/Classes/EventListener/PageLayoutListener.php
@@ -7,10 +7,11 @@ use TYPO3\CMS\Backend\Template\Components\ButtonBar;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Imaging\Icon;
 use TYPO3\CMS\Core\Imaging\IconFactory;
+use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Localization\LanguageService;
 
 /**
- * @todo can be removed in TYPO3 v13 because TYPO3 v13 provides this functionality:
+ * @todo can be removed when version for TYPO3 v12 and below is dropped because TYPO3 v13 provides this functionality:
  * @see https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/13.3/Feature-103789-AddCloseButtonToPageLayoutIfReturnUrlIsSet.html
  */
 class PageLayoutListener
@@ -18,7 +19,8 @@ class PageLayoutListener
     protected IconFactory $iconFactory;
     protected array $extConf;
 
-    public function __construct(IconFactory $iconFactory, ExtensionConfiguration $extensionConfiguration)
+    public function __construct(IconFactory $iconFactory, ExtensionConfiguration $extensionConfiguration,
+        protected Typo3Version $typo3Version)
     {
         $this->iconFactory = $iconFactory;
         $this->extConf = $extensionConfiguration->get('page_callouts');
@@ -27,7 +29,10 @@ class PageLayoutListener
     public function __invoke(ModifyPageLayoutContentEvent $event): void
     {
         // check if enabled in Extension Configuration
-        if (!$this->getExtensionConfigurationTypeBool('enableCloseButtonInPageModule', true)) {
+        if (!$this->getExtensionConfigurationTypeBool('enableCloseButtonInPageModule', true)
+                // if TYPO3 version is >= 13, do nothing since TYPO3
+            || $this->typo3Version->getMajorVersion() >= 13
+        ) {
             return;
         }
 


### PR DESCRIPTION
Must add version check, to make sure close button is not displayed in v13, since TYPO3 has this functionality since v13

Resolves: #35